### PR TITLE
fix: Use Title for Links

### DIFF
--- a/src/convert.ts
+++ b/src/convert.ts
@@ -161,7 +161,7 @@ const extendedCitation = (h:wikiLink,settings:ConversionSettings) =>  {
 
 const externalLink = (a:Node,settings:ConversionSettings,indent:number=0) => {
 	const l = a as Link
-	return "\\url{" + l.url + "}"
+	return "\\href{" + l.url + "}{" + l.title + "}"
 }
 
 const codeBlock = (a:Node,settings:ConversionSettings,indent:number=0) => {


### PR DESCRIPTION
Hi @mo-seph, thank you for this plugin!

Is there a reason, that markdown links with a title text in `[]` brackets are ignored when converted to latex? Otherwise, I would suggest converting them to a `href` including the link title.

Thanks and have a great day!

:information_source: Haven't tested this yet - just wanted to get your feedback first.